### PR TITLE
Make homepage faster

### DIFF
--- a/zaneapi/blueprints/api.py
+++ b/zaneapi/blueprints/api.py
@@ -32,6 +32,13 @@ def usage_count():
     return flask.jsonify({"usage_count": int(count)})
 
 
+@bp.route("/home_stats")
+def usage_count():
+    useage_count = current_app.redis.get("usage_count").decode()
+    user_count = current_app.redis.get("user_count").decode()
+    return flask.jsonify({"usage_count": int(useage_count), "user_count": int(user_count)})
+
+
 @bp.route("/auth")
 def auth():
     token = request.args.get("token", request.headers.get("Authorization"))

--- a/zaneapi/templates/index.html
+++ b/zaneapi/templates/index.html
@@ -103,11 +103,8 @@
         <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.0-beta1/dist/js/bootstrap.bundle.min.js" integrity="sha384-ygbV9kiqUc6oa4msXn9868pTtWMgiQaeYH7/t7LECLbyPA2x65Kgf80OJFdroafW" crossorigin="anonymous"></script>
         <script src="https://code.jquery.com/jquery-3.5.1.min.js"></script>
         <script>
-            $.getJSON("/api/user_count", function(d){
+            $.getJSON("/api/home_stats", function(d){
                 $("#user_count").text(d.user_count)
-            })
-
-            $.getJSON("/api/usage_count", function(d){
                 $("#usage_count").text(d.usage_count)
             })
         </script>


### PR DESCRIPTION
Why 2 requests instead of just 1?

Exposes both stats under one endpoint.